### PR TITLE
Alternative mouse shortcuts support

### DIFF
--- a/OpenMissionControl/OpenMissionControlCore.swift
+++ b/OpenMissionControl/OpenMissionControlCore.swift
@@ -16,6 +16,42 @@ import SwiftUI
 @_silgen_name("CoreDockSendNotification")
 func CoreDockSendNotification(_ notification: CFString, _ unknown: Int32) -> CGError
 
+protocol DisplayNameable {
+    var displayName: String { get }
+}
+
+enum WindowAction: Int, CaseIterable, DisplayNameable {
+    case none = 0
+    case minimize = 1
+    case zoom = 2
+    case close = 3
+    case quit = 4
+
+    var displayName: String {
+        switch self {
+        case .none: return "None"
+        case .minimize: return "Minimize"
+        case .zoom: return "Maximize"
+        case .close: return "Close"
+        case .quit: return "Quit"
+        }
+    }
+}
+
+enum Instigator: Int, CaseIterable, DisplayNameable {
+    case overlay
+    case keyboard
+    case mouse
+
+    var displayName: String {
+        switch self {
+        case .overlay: return "Overlay Click"
+        case .keyboard: return "Keyboard Shortcut"
+        case .mouse: return "Mouse Shortcut"
+        }
+    }
+}
+
 final class OpenMissionControlCore: ObservableObject {
     static let shared = OpenMissionControlCore()
     private let logger = Logger(
@@ -31,6 +67,8 @@ final class OpenMissionControlCore: ObservableObject {
     @AppStorage("shortcutClose") private var shortcutClose: Bool = false
     @AppStorage("shortcutMinimize") private var shortcutMinimize: Bool = false
     @AppStorage("shortcutMaximize") private var shortcutMaximize: Bool = false
+    @AppStorage("rightClickAction") private var rightClickAction: WindowAction = .none
+    @AppStorage("middleClickAction") private var middleClickAction: WindowAction = .none
 
     // MARK: - Lifecycle
 
@@ -64,11 +102,11 @@ final class OpenMissionControlCore: ObservableObject {
         MissionControlMonitor.shared.start()
 
         // Configure mouse event monitor
-        MouseEventMonitor.shared.setClickHandler { [weak self] location in
+        MouseEventMonitor.shared.setClickHandler { [weak self] location, button in
             guard let self = self else { return true }
 
-            self.logger.debug("Mouse clicked at: \(location.x), \(location.y)")
-            return self.handleMouseClick(at: location)
+            self.logger.debug("Mouse clicked at: \(location.x), \(location.y) (button: \(button.rawValue))")
+            return self.handleMouseClick(at: location, with: button)
         }
         MouseEventMonitor.shared.setMoveHandler { [weak self] location in
             guard let self = self else { return }
@@ -136,18 +174,38 @@ final class OpenMissionControlCore: ObservableObject {
     // MARK: - Mouse Event Handling
 
     @discardableResult
-    private func handleMouseClick(at location: CGPoint) -> Bool {
+    private func handleMouseClick(at location: CGPoint, with button: CGMouseButton) -> Bool {
         guard isOverlayShown else { return true }
 
         if let rect = overlayRect, rect.contains(location) {
-            logger.debug("Captured left click inside overlayRect at (\(location.x), \(location.y))")
-            handleOverlayClick(at: location)
-            return false
+            if button == .left {
+                logger.debug("Captured left click inside overlayRect at (\(location.x), \(location.y)).")
+                handleOverlayClick(at: location)
+                return false
+            } else {
+                logger.debug("Captured non-left click inside overlayRect at (\(location.x), \(location.y)), skipping.")
+                return true
+            }
         }
 
-        if hoveredWindow != nil {
-            logger.debug("Captured left click on hovered window at (\(location.x), \(location.y))")
-            hideOverlay()
+        if let window = hoveredWindow {
+            switch(button) {
+            case .left:
+                logger.debug("Captured left click on hovered window at (\(location.x), \(location.y)).")
+                hideOverlay()
+                return true
+            case .right:
+                logger.debug("Captured right click on hovered window at (\(location.x), \(location.y)).")
+                performWindowAction(window: window, action: rightClickAction, instigator: .mouse)
+                return rightClickAction == .none
+            case .center:
+                logger.debug("Captured middle click on hovered window at (\(location.x), \(location.y)).")
+                performWindowAction(window: window, action: middleClickAction, instigator: .mouse)
+                return middleClickAction == .none
+            default:
+                logger.debug("Captured non-default click (id \(button.rawValue)) on hovered window at (\(location.x), \(location.y)), skipping.")
+                return true
+            }
         }
 
         return true
@@ -165,33 +223,25 @@ final class OpenMissionControlCore: ObservableObject {
         // Check for Command key
         guard flags.contains(.maskCommand) else { return true }
 
-        let windowName = window[kCGWindowName as String] as? String ?? ""
-
         switch keyCode {
         case 12: // Q
             if shortcutQuit {
-                logger.info("Shortcut Quit triggered on window: \(windowName)")
-                quitApplication(window: window)
+                performWindowAction(window: window, action: .quit, instigator: .keyboard)
                 return false
             }
         case 13: // W
             if shortcutClose {
-                logger.info("Shortcut Close triggered on window: \(windowName)")
-                performWindowAction(window: window, action: kAXCloseButtonAttribute)
+                performWindowAction(window: window, action: .close, instigator: .keyboard)
                 return false
             }
         case 46: // M
             if shortcutMinimize {
-                logger.info("Shortcut Minimize triggered on window: \(windowName)")
-                performWindowAction(window: window, action: kAXMinimizeButtonAttribute)
+                performWindowAction(window: window, action: .minimize, instigator: .keyboard)
                 return false
             }
         case 3: // F
             if shortcutMaximize {
-                logger.info("Shortcut Maximize triggered on window: \(windowName)")
-                _ = CoreDockSendNotification("com.apple.expose.awake" as CFString, 0)
-                hideOverlay()
-                performWindowAction(window: window, action: kAXZoomButtonAttribute)
+                performWindowAction(window: window, action: .zoom, instigator: .keyboard)
                 return false
             }
         default:
@@ -279,11 +329,18 @@ final class OpenMissionControlCore: ObservableObject {
                         NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
                     let convertedY = screenHeight - y - 40
 
-                    let newFrame = NSRect(x: x + 8, y: convertedY - 8, width: 104, height: 40)
+                    let showQuit = UserDefaults.standard.object(forKey: "showQuitButton") as? Bool ?? false
+                    let showClose = UserDefaults.standard.object(forKey: "showCloseButton") as? Bool ?? true
+                    let showMinimize = UserDefaults.standard.object(forKey: "showMinimizeButton") as? Bool ?? true
+                    let showZoom = UserDefaults.standard.object(forKey: "showZoomButton") as? Bool ?? true
+                    let buttonCount = [showQuit, showClose, showMinimize, showZoom].filter { $0 }.count
+                    let overlayWidth = CGFloat(12 + buttonCount * 32)
+
+                    let newFrame = NSRect(x: x + 8, y: convertedY - 8, width: overlayWidth, height: 40)
                     overlayWindow?.setFrame(newFrame, display: true)
                     overlayWindow?.orderFront(nil)
 
-                    let cgOverlayRect = CGRect(x: x + 8, y: y + 8, width: 104, height: 40)
+                    let cgOverlayRect = CGRect(x: x + 8, y: y + 8, width: overlayWidth, height: 40)
                     overlayRect = cgOverlayRect
                     hoveredWindow = windowInfo
 
@@ -309,46 +366,59 @@ final class OpenMissionControlCore: ObservableObject {
             UserDefaults.standard.object(forKey: "showMinimizeButton") as? Bool ?? true
         let showZoom = UserDefaults.standard.object(forKey: "showZoomButton") as? Bool ?? true
 
-        let windowName = window[kCGWindowName as String] as? String ?? ""
-
         if showQuit {
             if localX >= currentX, localX <= currentX + 24 {
-                logger.info("Quit button clicked on window: \(windowName)")
-                quitApplication(window: window)
+                performWindowAction(window: window, action: .quit, instigator: .overlay)
             }
             currentX += 32
         }
 
         if showClose {
             if localX >= currentX, localX <= currentX + 24 {
-                logger.info("Close button clicked on window: \(windowName)")
-                performWindowAction(window: window, action: kAXCloseButtonAttribute)
+                performWindowAction(window: window, action: .close, instigator: .overlay)
             }
             currentX += 32
         }
 
         if showMinimize {
             if localX >= currentX, localX <= currentX + 24 {
-                logger.info("Minimize button clicked on window: \(windowName)")
-                performWindowAction(window: window, action: kAXMinimizeButtonAttribute)
+                performWindowAction(window: window, action: .minimize, instigator: .overlay)
             }
             currentX += 32
         }
 
         if showZoom {
             if localX >= currentX, localX <= currentX + 24 {
-                logger.info("Zoom button clicked on window: \(windowName)")
-
-                _ = CoreDockSendNotification("com.apple.expose.awake" as CFString, 0)
-                hideOverlay()
-
-                performWindowAction(window: window, action: kAXZoomButtonAttribute)
+                performWindowAction(window: window, action: .zoom, instigator: .overlay)
             }
             currentX += 32
         }
     }
 
-    private func performWindowAction(window: [String: Any], action: String) {
+    private func performWindowAction(window: [String: Any], action: WindowAction, instigator: Instigator) {
+        let windowName = window[kCGWindowName as String] as? String ?? ""
+
+        switch(action) {
+        case .quit:
+            logger.info("\(instigator.displayName) Quit triggered on window: \(windowName)")
+            quitApplication(window: window)
+        case .minimize:
+            logger.info("\(instigator.displayName) Minimize triggered on window: \(windowName)")
+            performOSWindowAction(window: window, action: kAXMinimizeButtonAttribute)
+        case .zoom:
+            logger.info("\(instigator.displayName) Maximize triggered on window: \(windowName)")
+            _ = CoreDockSendNotification("com.apple.expose.awake" as CFString, 0)
+            hideOverlay()
+            performOSWindowAction(window: window, action: kAXZoomButtonAttribute)
+        case .close:
+            logger.info("\(instigator.displayName) Close triggered on window: \(windowName)")
+            performOSWindowAction(window: window, action: kAXCloseButtonAttribute)
+        default:
+            break
+        }
+    }
+
+    private func performOSWindowAction(window: [String: Any], action: String) {
         guard let pid = window[kCGWindowOwnerPID as String] as? pid_t,
               let windowID = window[kCGWindowNumber as String] as? CGWindowID
         else {

--- a/OpenMissionControl/Utilities/MouseEventMonitor.swift
+++ b/OpenMissionControl/Utilities/MouseEventMonitor.swift
@@ -17,7 +17,7 @@ class MouseEventMonitor {
 
     // MARK: - Types
 
-    typealias ClickHandler = (_ location: CGPoint) -> Bool
+    typealias ClickHandler = (_ location: CGPoint, _ buttonCode: CGMouseButton) -> Bool
     typealias MoveHandler = (_ location: CGPoint) -> Void
     typealias KeyHandler = (_ flags: CGEventFlags, _ keyCode: CGKeyCode) -> Bool
 
@@ -83,7 +83,10 @@ class MouseEventMonitor {
     // MARK: - Private: Click Monitoring
 
     private func startClickMonitoring() {
-        let eventMask = (1 << CGEventType.leftMouseDown.rawValue) | (1 << CGEventType.keyDown.rawValue)
+        let eventMask = (1 << CGEventType.leftMouseDown.rawValue)
+            | (1 << CGEventType.rightMouseDown.rawValue)
+            | (1 << CGEventType.otherMouseDown.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -156,8 +159,8 @@ class MouseEventMonitor {
 
     /// Returns `true` if the event should be passed down the event chain, `false` to swallow it.
     @discardableResult
-    fileprivate func handleClick(at location: CGPoint) -> Bool {
-        return clickHandler?(location) ?? true
+    fileprivate func handleClick(at location: CGPoint, with button: CGMouseButton) -> Bool {
+        return clickHandler?(location, button) ?? true
     }
 
     private func handleMove(to location: CGPoint) {
@@ -194,9 +197,23 @@ private func mouseEventMonitorClickCallback(
 
     if type == .leftMouseDown {
         let location = event.location
-        let passDown = MouseEventMonitor.shared.handleClick(at: location)
+        let passDown = MouseEventMonitor.shared.handleClick(at: location, with: .left)
         if !passDown {
             return nil
+        }
+    } else if type == .rightMouseDown {
+        let location = event.location
+        let passDown = MouseEventMonitor.shared.handleClick(at: location, with: .right)
+        if !passDown {
+            return nil
+        }
+    } else if type == .otherMouseDown {
+        let location = event.location
+        if let button = CGMouseButton(rawValue: UInt32(event.getIntegerValueField(.mouseEventButtonNumber))) {
+            let passDown = MouseEventMonitor.shared.handleClick(at: location, with: button)
+            if !passDown {
+                return nil
+            }
         }
     } else if type == .keyDown {
         let flags = event.flags

--- a/OpenMissionControl/Views/OverlayView.swift
+++ b/OpenMissionControl/Views/OverlayView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum OverlayTheme: String, CaseIterable {
+enum OverlayTheme: String, CaseIterable, DisplayNameable {
     case `default`
     case minimal
     case coloredMinimal

--- a/OpenMissionControl/Views/SettingsView.swift
+++ b/OpenMissionControl/Views/SettingsView.swift
@@ -10,6 +10,22 @@ import Combine
 import OSLog
 import SwiftUI
 
+// MARK: - Icon color gradient builders
+
+private func solidColor(color: Color) -> LinearGradient {
+    return LinearGradient(
+        colors: [color.opacity(0.85), color], startPoint: .top,
+        endPoint: .bottom
+    )
+}
+
+private let rainbowColor = LinearGradient(
+   colors: [
+        Color.red, Color.orange, Color.yellow, Color.green,
+        Color.blue, Color.purple,
+    ], startPoint: .top, endPoint: .bottom
+)
+
 // MARK: - Accessibility Row
 
 struct AccessibilityRow: View {
@@ -71,17 +87,17 @@ struct AccessibilityRow: View {
 
 struct SettingToggleRow: View {
     let icon: String?
-    let iconColor: Color
+    let iconColor: LinearGradient
     let title: String
     let subtitle: String?
     @Binding var isOn: Bool
 
     init(
-        icon: String? = nil, iconColor: Color = .blue, title: String, subtitle: String? = nil,
+        icon: String? = nil, iconColor: LinearGradient? = nil, title: String, subtitle: String? = nil,
         isOn: Binding<Bool>
     ) {
         self.icon = icon
-        self.iconColor = iconColor
+        self.iconColor = iconColor ?? solidColor(color: .blue)
         self.title = title
         self.subtitle = subtitle
         _isOn = isOn
@@ -92,12 +108,7 @@ struct SettingToggleRow: View {
             if let icon {
                 ZStack {
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(
-                            LinearGradient(
-                                colors: [iconColor.opacity(0.85), iconColor], startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
+                        .fill(iconColor)
                         .frame(width: 28, height: 28)
                     Image(systemName: icon)
                         .font(.system(size: 13, weight: .semibold))
@@ -126,6 +137,56 @@ struct SettingToggleRow: View {
         .padding(.vertical, 8)
     }
 }
+
+struct SettingPickerRow<Value>: View where Value: Hashable & CaseIterable & DisplayNameable {
+    let icon: String?
+    let iconColor: LinearGradient
+    let title: String
+    @Binding var selectedValue: Value
+
+    init(
+        icon: String? = nil, iconColor: LinearGradient? = nil, title: String,
+        selectedValue: Binding<Value>
+    ) {
+        self.icon = icon
+        self.iconColor = iconColor ?? solidColor(color: .blue)
+        self.title = title
+        _selectedValue = selectedValue
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let icon {
+                ZStack {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(iconColor)
+                    .frame(width: 28, height: 28)
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+            }
+
+            Spacer()
+
+            Picker("", selection: $selectedValue) {
+                ForEach(Array(Value.allCases), id: \.self) { value in
+                    Text(value.displayName).tag(value)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 100)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+}
+
 
 // MARK: - Section Card
 
@@ -168,6 +229,8 @@ struct SettingsView: View {
     @AppStorage("shortcutClose") private var shortcutClose: Bool = false
     @AppStorage("shortcutMinimize") private var shortcutMinimize: Bool = false
     @AppStorage("shortcutMaximize") private var shortcutMaximize: Bool = false
+    @AppStorage("rightClickAction") private var rightClickAction: WindowAction = .none
+    @AppStorage("middleClickAction") private var middleClickAction: WindowAction = .none
 
     @State private var launchAtLogin: Bool = LaunchAtLoginManager.isEnabled
     private let logger = Logger(
@@ -258,46 +321,18 @@ struct SettingsView: View {
                     sectionHeader("Overlay")
 
                     SettingsCard {
-                        HStack(spacing: 12) {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                    .fill(
-                                        LinearGradient(
-                                            colors: [
-                                                Color.red, Color.orange, Color.yellow, Color.green,
-                                                Color.blue, Color.purple,
-                                            ], startPoint: .top, endPoint: .bottom
-                                        )
-                                    )
-                                    .frame(width: 28, height: 28)
-                                Image(systemName: "paintpalette.fill")
-                                    .font(.system(size: 13, weight: .semibold))
-                                    .foregroundColor(.white)
-                            }
-
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text("Theme")
-                                    .font(.system(size: 13, weight: .medium))
-                            }
-
-                            Spacer()
-
-                            Picker("", selection: $currentTheme) {
-                                ForEach(OverlayTheme.allCases, id: \.self) { theme in
-                                    Text(theme.displayName).tag(theme)
-                                }
-                            }
-                            .labelsHidden()
-                            .frame(width: 100)
-                        }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
+                        SettingPickerRow<OverlayTheme>(
+                            icon: "paintpalette.fill",
+                            iconColor: rainbowColor,
+                            title: "Theme",
+                            selectedValue: $currentTheme
+                        )
 
                         SettingsDivider()
 
                         SettingToggleRow(
                             icon: "power",
-                            iconColor: .purple,
+                            iconColor: solidColor(color: .purple),
                             title: "Quit Button",
                             isOn: $showQuitButton
                         )
@@ -306,7 +341,7 @@ struct SettingsView: View {
 
                         SettingToggleRow(
                             icon: "xmark",
-                            iconColor: .red,
+                            iconColor: solidColor(color: .red),
                             title: "Close Button",
                             isOn: $showCloseButton
                         )
@@ -315,7 +350,7 @@ struct SettingsView: View {
 
                         SettingToggleRow(
                             icon: "minus",
-                            iconColor: .yellow,
+                            iconColor: solidColor(color: .yellow),
                             title: "Minimize Button",
                             isOn: $showMinimizeButton
                         )
@@ -324,7 +359,7 @@ struct SettingsView: View {
 
                         SettingToggleRow(
                             icon: "arrow.up.backward.and.arrow.down.forward",
-                            iconColor: .green,
+                            iconColor: solidColor(color: .green),
                             title: "Maximize Button",
                             isOn: $showZoomButton
                         )
@@ -354,14 +389,13 @@ struct SettingsView: View {
                     }
                 }
 
-                // MARK: Shortcuts
+                // MARK: Keyboard Shortcuts
 
                 VStack(alignment: .leading, spacing: 6) {
-                    sectionHeader("Shortcuts")
+                    sectionHeader("Keyboard Shortcuts")
 
                     SettingsCard {
                         SettingToggleRow(
-                            iconColor: .purple,
                             title: "Quit (⌘Q)",
                             isOn: $shortcutQuit
                         )
@@ -369,7 +403,6 @@ struct SettingsView: View {
                         SettingsDivider()
 
                         SettingToggleRow(
-                            iconColor: .red,
                             title: "Close (⌘W)",
                             isOn: $shortcutClose
                         )
@@ -377,7 +410,6 @@ struct SettingsView: View {
                         SettingsDivider()
 
                         SettingToggleRow(
-                            iconColor: .yellow,
                             title: "Minimize (⌘M)",
                             isOn: $shortcutMinimize
                         )
@@ -385,9 +417,28 @@ struct SettingsView: View {
                         SettingsDivider()
 
                         SettingToggleRow(
-                            iconColor: .green,
                             title: "Maximize (⌘F)",
                             isOn: $shortcutMaximize
+                        )
+                    }
+                }
+
+                // MARK: Mouse Shortcuts
+
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionHeader("Mouse Shortcuts")
+
+                    SettingsCard {
+                        SettingPickerRow<WindowAction>(
+                            title: "Right-click action",
+                            selectedValue: $rightClickAction
+                        )
+
+                        SettingsDivider()
+
+                        SettingPickerRow<WindowAction>(
+                            title: "Middle-click action",
+                            selectedValue: $middleClickAction
                         )
                     }
                 }


### PR DESCRIPTION
Hey, first of all, thanks for the great app, it works really well 😄 I thought it would be cool if it could also support managing windows without the need to use the overlay - simply hover and middle click to close a window - so I added it. I will note that I'm very new to both Swift and macOS itself, so hopefully I didn't make too many mistakes - would love to hear your comments.

_________________

Adds right and middle click detection inside Mission Control. The action to be performed is customizable using a picker in Settings view. Both click actions are set to None by default and must be manually enabled by the user.

<img width="400" height="515" alt="Screenshot 2026-06-24 at 02-17-00" src="https://github.com/user-attachments/assets/f624815b-20d1-40e9-9a7b-3467526df920" />


OpenMissionControlCore refactors:
* available window actions (quit, close, minimize, maximize) are now grouped in a `WindowAction` enum
* the method `performWindowAction` has been renamed to `performWindowOSAction`
* a new method `performWindowAction` has been added to have a single code path for all possible actions - it is used by both mouse, keyboard and overlay handler functions -  removes some redundancy
* new `Instigator` enum has been added and is passed to `performWindowAction` in order not to break current debug logging functionality - we can still track who (overlay, keyboard, mouse click) requested the window action despite printing being kept solely within `performWindowAction`
* fixes a bug where the hardcoded width of the overlay was small enough so that the 4th overlay button could never be clicked, and unnecessarily blocked some space when only 1 or 2 icons were enabled. The overlay rect width is now calculated dynamically

SettingsView refactors:
* since Theme is no longer the only picker in the Settings view, a `SettingPickerRow` class has been introduced - similar to the existing `SettingToggleRow`
* `SettingPickerRow` and `SettingToggleRow` now receive color as `LinearGradient` rather than raw `Color` - required to retain the rainbow icon in Theme within `SettingPickerRow`. Additional helper builder function `solidColor` has been added to convert colors to linear gradients