### PR TITLE
Add keyboard navigation to Mission Control

### DIFF
--- a/OpenMissionControl/OpenMissionControlCore.swift
+++ b/OpenMissionControl/OpenMissionControlCore.swift
@@ -52,6 +52,48 @@ enum Instigator: Int, CaseIterable, DisplayNameable {
     }
 }
 
+/// A user-selectable extra key for Mission Control keyboard navigation. The raw value is the
+/// macOS virtual keycode of each letter (which are not alphabetical), so `keyCode` maps directly.
+/// `.none` disables the extra key. Cases are declared alphabetically for a tidy picker order.
+enum NavigationKey: Int, CaseIterable, DisplayNameable {
+    case none = -1
+    case a = 0
+    case b = 11
+    case c = 8
+    case d = 2
+    case e = 14
+    case f = 3
+    case g = 5
+    case h = 4
+    case i = 34
+    case j = 38
+    case k = 40
+    case l = 37
+    case m = 46
+    case n = 45
+    case o = 31
+    case p = 35
+    case q = 12
+    case r = 15
+    case s = 1
+    case t = 17
+    case u = 32
+    case v = 9
+    case w = 13
+    case x = 7
+    case y = 16
+    case z = 6
+
+    var displayName: String {
+        self == .none ? "None" : String(describing: self).uppercased()
+    }
+
+    /// The virtual keycode this key represents, or `nil` when disabled (`.none`).
+    var keyCode: CGKeyCode? {
+        self == .none ? nil : CGKeyCode(rawValue)
+    }
+}
+
 final class OpenMissionControlCore: ObservableObject {
     static let shared = OpenMissionControlCore()
     private let logger = Logger(
@@ -62,6 +104,10 @@ final class OpenMissionControlCore: ObservableObject {
 
     private var windows: [[String: Any]] = []
     private var windowFetchTimer: Timer?
+
+    /// Index into `sortedWindows` of the keyboard-selected window. `-1` means no keyboard
+    /// selection yet — the sentinel that keeps mouse-only usage untouched until the first Tab.
+    private var selectedIndex: Int = -1
     @AppStorage(SettingsDefaults.Key.updateDuration) private var updateDuration: Double =
         SettingsDefaults.updateDuration
     @AppStorage(SettingsDefaults.Key.shortcutQuit) private var shortcutQuit: Bool =
@@ -72,6 +118,12 @@ final class OpenMissionControlCore: ObservableObject {
         SettingsDefaults.shortcutMinimize
     @AppStorage(SettingsDefaults.Key.shortcutMaximize) private var shortcutMaximize: Bool =
         SettingsDefaults.shortcutMaximize
+    @AppStorage(SettingsDefaults.Key.keyboardNavigation) private var keyboardNavigation: Bool =
+        SettingsDefaults.keyboardNavigation
+    @AppStorage(SettingsDefaults.Key.tabNavigationExtraKey) private var tabNavigationExtraKey:
+        NavigationKey = SettingsDefaults.tabNavigationExtraKey
+    @AppStorage(SettingsDefaults.Key.enterNavigationExtraKey) private var enterNavigationExtraKey:
+        NavigationKey = SettingsDefaults.enterNavigationExtraKey
     @AppStorage(SettingsDefaults.Key.rightClickAction) private var rightClickAction: WindowAction =
         SettingsDefaults.rightClickAction
     @AppStorage(SettingsDefaults.Key.middleClickAction) private var middleClickAction:
@@ -161,6 +213,7 @@ final class OpenMissionControlCore: ObservableObject {
         logger.info("Mission Control state changed: \(state.rawValue)")
 
         if state.isActive {
+            selectedIndex = -1
             isOverlayShown = true
             showOverlay()
         } else {
@@ -176,6 +229,7 @@ final class OpenMissionControlCore: ObservableObject {
 
         logger.info("Active space changed, recreating windows and overlay.")
 
+        selectedIndex = -1
         recreateOverlay()
     }
 
@@ -226,9 +280,26 @@ final class OpenMissionControlCore: ObservableObject {
     // MARK: - Key Event Handling
 
     private func handleKeyPress(flags: CGEventFlags, keyCode: CGKeyCode) -> Bool {
-        guard isOverlayShown, let window = hoveredWindow else { return true }
+        guard isOverlayShown else { return true }
 
-        // Check for Command key
+        // Keyboard navigation: Tab / Shift+Tab cycle the selection, Return / Enter activates it.
+        // No modifier is required, so this must be handled before the Command-shortcut path below.
+        // Command is explicitly excluded so ⌘Tab (app switcher) keeps passing through untouched.
+        if keyboardNavigation, !flags.contains(.maskCommand) {
+            // Tab and Return/Enter are always active; the extra keys are user-configurable
+            // (default D to rotate, K to activate). If both map to the same key, rotate wins.
+            if keyCode == 48 || tabNavigationExtraKey.keyCode == keyCode {
+                moveSelection(by: flags.contains(.maskShift) ? -1 : 1)
+                return false
+            }
+            if keyCode == 36 || keyCode == 76 || enterNavigationExtraKey.keyCode == keyCode {
+                activateSelection()
+                return false
+            }
+        }
+
+        // Command-modified window actions operate on the hovered (or keyboard-selected) window.
+        guard let window = hoveredWindow else { return true }
         guard flags.contains(.maskCommand) else { return true }
 
         switch keyCode {
@@ -257,6 +328,108 @@ final class OpenMissionControlCore: ObservableObject {
         }
 
         return true
+    }
+
+    // MARK: - Keyboard Navigation
+
+    private func frame(of window: [String: Any]) -> CGRect? {
+        guard let bounds = window[kCGWindowBounds as String] as? [String: CGFloat],
+              let x = bounds["X"], let y = bounds["Y"],
+              let w = bounds["Width"], let h = bounds["Height"]
+        else { return nil }
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    /// The point used to hover and click a thumbnail. Near the top-left corner rather than the
+    /// center: with "group windows by application", thumbnails stack and each front window hides
+    /// the center of the one behind it, so a center point can never reach the back windows. The
+    /// exposed top-left "shoulder" of each stacked window is unique to it. Kept below OMC's own
+    /// button overlay (top-left, ~48pt tall) so activating never accidentally presses a button.
+    private func selectionPoint(for frame: CGRect) -> CGPoint {
+        return CGPoint(x: frame.minX + 24, y: frame.minY + 64)
+    }
+
+    /// Windows ordered for Tab traversal: row first (top to bottom), then column (left to right).
+    /// More predictable visually than the z-order that `CGWindowListCopyWindowInfo` returns.
+    ///
+    /// Rows are built greedily from a stable top-to-bottom sort: a thumbnail joins the current
+    /// row when its top is within `rowTolerance` of that row's top, otherwise it starts a new row.
+    /// This is a deterministic total order — unlike a direct `abs(dy) > tol` comparator, which is
+    /// not a strict weak ordering and yields an unspecified result from `sorted`. Tune `rowTolerance`
+    /// if the tab order looks off.
+    private var sortedWindows: [[String: Any]] {
+        let rowTolerance: CGFloat = 50
+
+        let framed = windows.compactMap { win -> (win: [String: Any], frame: CGRect)? in
+            guard let f = frame(of: win) else { return nil }
+            return (win, f)
+        }
+        .sorted { $0.frame.minY < $1.frame.minY }
+
+        var rows: [[(win: [String: Any], frame: CGRect)]] = []
+        for item in framed {
+            if let rowTop = rows.last?.first?.frame.minY,
+               abs(item.frame.minY - rowTop) <= rowTolerance {
+                rows[rows.count - 1].append(item)
+            } else {
+                rows.append([item])
+            }
+        }
+
+        return rows.flatMap { row in
+            row.sorted { $0.frame.minX < $1.frame.minX }.map(\.win)
+        }
+    }
+
+    /// Moves the keyboard selection by `delta` (with wrap-around) and posts a synthetic
+    /// `.mouseMoved` to the selected thumbnail's center. Mission Control then draws its own
+    /// native highlight, and `hoveredWindow` syncs so the ⌘Q/W/M/F shortcuts keep working
+    /// against the keyboard selection without any change to their switch.
+    private func moveSelection(by delta: Int) {
+        let list = sortedWindows
+        guard !list.isEmpty else { return }
+
+        selectedIndex = selectedIndex < 0
+            ? (delta > 0 ? 0 : list.count - 1)
+            : ((selectedIndex + delta) % list.count + list.count) % list.count
+
+        guard let f = frame(of: list[selectedIndex]) else { return }
+        let pt = selectionPoint(for: f)
+
+        // NB: `.mouseMoved` (not CGWarpMouseCursorPosition) — Mission Control only repaints its
+        // highlight in response to an actual move event.
+        CGEvent(
+            mouseEventSource: nil, mouseType: .mouseMoved,
+            mouseCursorPosition: pt, mouseButton: .left
+        )?.post(tap: .cghidEventTap)
+
+        updateOverlay(at: pt) // sync hoveredWindow immediately instead of waiting for the poller
+    }
+
+    /// Activates the current keyboard selection by posting a synthetic left click on its
+    /// thumbnail center. The click flows through the normal `handleMouseClick` path, which
+    /// hides the overlay and lets Mission Control raise the window and dismiss itself.
+    private func activateSelection() {
+        let list = sortedWindows
+        guard selectedIndex >= 0, selectedIndex < list.count,
+              let f = frame(of: list[selectedIndex]) else { return }
+        let pt = selectionPoint(for: f)
+
+        let post: (CGEventType) -> Void = { type in
+            CGEvent(
+                mouseEventSource: nil, mouseType: type,
+                mouseCursorPosition: pt, mouseButton: .left
+            )?.post(tap: .cghidEventTap)
+        }
+
+        // Land Mission Control's hover on this thumbnail, then click it. The mouseUp is delayed:
+        // a zero-duration synthetic click is unreliably registered by Mission Control as a
+        // selection. The click flows through handleMouseClick, which raises the window.
+        post(.mouseMoved)
+        post(.leftMouseDown)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            post(.leftMouseUp)
+        }
     }
 
     // MARK: - Window Fetching

--- a/OpenMissionControl/Utilities/MouseEventMonitor.swift
+++ b/OpenMissionControl/Utilities/MouseEventMonitor.swift
@@ -41,6 +41,14 @@ class MouseEventMonitor {
     fileprivate var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
+    // MARK: - Key Monitoring (CGEvent tap)
+
+    // A dedicated tap at the HID level. A `.cgSessionEventTap` does NOT receive key events while
+    // Mission Control is active (the WindowServer grabs them first), even though it still receives
+    // mouse events. Tapping at `.cghidEventTap` sits below that grab, so keys come through.
+    fileprivate var keyEventTap: CFMachPort?
+    private var keyRunLoopSource: CFRunLoopSource?
+
     // MARK: - Move Monitoring (CGEvent polling)
 
     private var moveThread: Thread?
@@ -66,6 +74,7 @@ class MouseEventMonitor {
         isMonitoring = true
 
         startClickMonitoring()
+        startKeyMonitoring()
         startMoveMonitoring()
 
         logger.info("Mouse event monitoring started.")
@@ -75,6 +84,7 @@ class MouseEventMonitor {
         guard isMonitoring else { return }
 
         stopClickMonitoring()
+        stopKeyMonitoring()
         stopMoveMonitoring()
 
         isMonitoring = false
@@ -87,7 +97,6 @@ class MouseEventMonitor {
         let eventMask = (1 << CGEventType.leftMouseDown.rawValue)
             | (1 << CGEventType.rightMouseDown.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
-            | (1 << CGEventType.keyDown.rawValue)
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -110,6 +119,46 @@ class MouseEventMonitor {
 
         CGEvent.tapEnable(tap: tap, enable: true)
         logger.info("Click event tap started.")
+    }
+
+    private func startKeyMonitoring() {
+        let eventMask = (1 << CGEventType.keyDown.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: mouseEventMonitorKeyCallback,
+            userInfo: nil
+        ) else {
+            logger.error("Failed to create key event tap. Please grant Accessibility permissions.")
+            return
+        }
+
+        keyEventTap = tap
+        keyRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+
+        if let source = keyRunLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+
+        CGEvent.tapEnable(tap: tap, enable: true)
+        logger.info("Key event tap started (HID level).")
+    }
+
+    private func stopKeyMonitoring() {
+        if let tap = keyEventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+
+        if let source = keyRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+
+        keyEventTap = nil
+        keyRunLoopSource = nil
+        logger.info("Key event tap stopped.")
     }
 
     private func stopClickMonitoring() {
@@ -216,7 +265,28 @@ private func mouseEventMonitorClickCallback(
                 return nil
             }
         }
-    } else if type == .keyDown {
+    }
+
+    return Unmanaged.passRetained(event)
+}
+
+// MARK: - C Callback for Key Events
+
+private func mouseEventMonitorKeyCallback(
+    proxy _: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    refcon _: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    // Re-enable tap if it was disabled by timeout or user input
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        if let tap = MouseEventMonitor.shared.keyEventTap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+        return Unmanaged.passRetained(event)
+    }
+
+    if type == .keyDown {
         let flags = event.flags
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
         let passDown = MouseEventMonitor.shared.handleKey(flags: flags, keyCode: keyCode)

--- a/OpenMissionControl/Utilities/SettingsDefaults.swift
+++ b/OpenMissionControl/Utilities/SettingsDefaults.swift
@@ -26,6 +26,10 @@ enum SettingsDefaults {
         static let shortcutMinimize = "shortcutMinimize"
         static let shortcutMaximize = "shortcutMaximize"
 
+        static let keyboardNavigation = "keyboardNavigation"
+        static let tabNavigationExtraKey = "tabNavigationExtraKey"
+        static let enterNavigationExtraKey = "enterNavigationExtraKey"
+
         static let rightClickAction = "rightClickAction"
         static let middleClickAction = "middleClickAction"
     }
@@ -46,6 +50,10 @@ enum SettingsDefaults {
     static let shortcutClose: Bool = false
     static let shortcutMinimize: Bool = false
     static let shortcutMaximize: Bool = false
+
+    static let keyboardNavigation: Bool = true
+    static let tabNavigationExtraKey: NavigationKey = .d
+    static let enterNavigationExtraKey: NavigationKey = .k
 
     static let rightClickAction: WindowAction = .none
     static let middleClickAction: WindowAction = .none

--- a/OpenMissionControl/Views/SettingsView.swift
+++ b/OpenMissionControl/Views/SettingsView.swift
@@ -239,6 +239,12 @@ struct SettingsView: View {
         SettingsDefaults.shortcutMinimize
     @AppStorage(SettingsDefaults.Key.shortcutMaximize) private var shortcutMaximize: Bool =
         SettingsDefaults.shortcutMaximize
+    @AppStorage(SettingsDefaults.Key.keyboardNavigation) private var keyboardNavigation: Bool =
+        SettingsDefaults.keyboardNavigation
+    @AppStorage(SettingsDefaults.Key.tabNavigationExtraKey) private var tabNavigationExtraKey:
+        NavigationKey = SettingsDefaults.tabNavigationExtraKey
+    @AppStorage(SettingsDefaults.Key.enterNavigationExtraKey) private var enterNavigationExtraKey:
+        NavigationKey = SettingsDefaults.enterNavigationExtraKey
     @AppStorage(SettingsDefaults.Key.rightClickAction) private var rightClickAction: WindowAction =
         SettingsDefaults.rightClickAction
     @AppStorage(SettingsDefaults.Key.middleClickAction) private var middleClickAction:
@@ -407,6 +413,28 @@ struct SettingsView: View {
                     sectionHeader("Keyboard Shortcuts")
 
                     SettingsCard {
+                        SettingToggleRow(
+                            title: "Tab Navigation",
+                            subtitle: "Cycle windows with Tab / ⇧Tab, activate with ↵",
+                            isOn: $keyboardNavigation
+                        )
+
+                        SettingsDivider()
+
+                        SettingPickerRow<NavigationKey>(
+                            title: "Tab Navigation Extra Key",
+                            selectedValue: $tabNavigationExtraKey
+                        )
+
+                        SettingsDivider()
+
+                        SettingPickerRow<NavigationKey>(
+                            title: "Enter Navigation Extra Key",
+                            selectedValue: $enterNavigationExtraKey
+                        )
+
+                        SettingsDivider()
+
                         SettingToggleRow(
                             title: "Quit (⌘Q)",
                             isOn: $shortcutQuit


### PR DESCRIPTION
## Motivation

Today the only way to pick a window in Mission Control is the trackpad. This adds a keyboard layer **on top of** the native Mission Control layout and animation — unlike alt-tab-style switchers that replace the whole view. It fits the project's goal of being an open-source alternative to Mission Control Plus (which has keyboard navigation).

**Design constraint:** mouse usage is untouched. Open Mission Control and use the trackpad and everything behaves exactly as before. Keyboard selection only begins on the first key press.

## What it does

- `Tab` / `Shift+Tab` cycle the selection between the visible thumbnails (row-major, with wrap-around).
- `Return` / `Enter` activate the selected window (raise it and dismiss Mission Control).
- Configurable **extra keys** (default `D` to rotate, `K` to activate) via new pickers in Settings, behind a `Tab Navigation` toggle (default on).
- The existing `⌘Q` / `⌘W` / `⌘M` / `⌘F` shortcuts now operate on the keyboard selection too.

## How it works

- Instead of drawing a custom highlight, selection posts a synthetic `.mouseMoved` to the target thumbnail, so **Mission Control paints its own native highlight** and `hoveredWindow` stays in sync — the existing Cmd shortcuts keep working against the selection with no change to their switch.
- `selectedIndex` starts at `-1` (no selection) so opening Mission Control never moves the pointer; mouse-only use stays identical until the first key press.
- Key events are captured with a **dedicated HID-level tap** (`.cghidEventTap`). A session-level tap does not receive key events while Mission Control is active (the WindowServer grabs them first), even though it still receives mouse events. The existing mouse tap is left untouched at session level.
- Selection targets each thumbnail's **top-left shoulder** rather than its center, so windows stacked by "group windows by application" (whose centers are hidden behind the front window) remain reachable, while staying clear of the overlay's button bar.
- Activation synthesizes a click (`.mouseMoved` → down → 50ms → up); a zero-duration synthetic click is unreliably registered by Mission Control.

## Testing

Verified manually with several windows across multiple apps in one space, with and without "group windows by application": Tab/Shift+Tab cycling with wrap-around, Enter/activation, the Cmd shortcuts operating on the keyboard selection, mouse hover/click unchanged, and clean reset when reopening Mission Control.

All new settings follow the existing `SettingsDefaults` / `@AppStorage` / `SettingToggleRow` / `SettingPickerRow` patterns.