### PR TITLE
Customizable window controls

### DIFF
--- a/OpenMissionControl/OpenMissionControlCore.swift
+++ b/OpenMissionControl/OpenMissionControlCore.swift
@@ -52,6 +52,15 @@ enum Instigator: Int, CaseIterable, DisplayNameable {
     }
 }
 
+enum KeyboardKey: CGKeyCode {
+    case returnKey = 36
+    case keypadEnter = 76
+    case quit = 12
+    case close = 13
+    case minimize = 46
+    case maximize = 3
+}
+
 final class OpenMissionControlCore: ObservableObject {
     static let shared = OpenMissionControlCore()
     private let logger = Logger(
@@ -72,6 +81,8 @@ final class OpenMissionControlCore: ObservableObject {
         SettingsDefaults.shortcutMinimize
     @AppStorage(SettingsDefaults.Key.shortcutMaximize) private var shortcutMaximize: Bool =
         SettingsDefaults.shortcutMaximize
+    @AppStorage(SettingsDefaults.Key.shortcutActivateWindow) private var shortcutActivateWindow:
+        Bool = SettingsDefaults.shortcutActivateWindow
     @AppStorage(SettingsDefaults.Key.rightClickAction) private var rightClickAction: WindowAction =
         SettingsDefaults.rightClickAction
     @AppStorage(SettingsDefaults.Key.middleClickAction) private var middleClickAction:
@@ -109,20 +120,20 @@ final class OpenMissionControlCore: ObservableObject {
         }
         MissionControlMonitor.shared.start()
 
-        // Configure mouse event monitor
-        MouseEventMonitor.shared.setClickHandler { [weak self] location, button in
+        // Configure input event monitor
+        InputEventMonitor.shared.setClickHandler { [weak self] location, button in
             guard let self = self else { return true }
 
             self.logger.debug("Mouse clicked at: \(location.x), \(location.y) (button: \(button.rawValue))")
             return self.handleMouseClick(at: location, with: button)
         }
-        MouseEventMonitor.shared.setMoveHandler { [weak self] location in
+        InputEventMonitor.shared.setMoveHandler { [weak self] location in
             guard let self = self else { return }
 
             self.logger.debug("Mouse moved to: \(location.x), \(location.y)")
             self.handleMouseMove(to: location)
         }
-        MouseEventMonitor.shared.setKeyHandler { [weak self] flags, keyCode in
+        InputEventMonitor.shared.setKeyHandler { [weak self] flags, keyCode in
             guard let self = self else { return true }
 
             return self.handleKeyPress(flags: flags, keyCode: keyCode)
@@ -143,7 +154,7 @@ final class OpenMissionControlCore: ObservableObject {
         axTrustedTimer?.invalidate()
         axTrustedTimer = nil
         MissionControlMonitor.shared.stop()
-        MouseEventMonitor.shared.stop()
+        InputEventMonitor.shared.stop()
         NSWorkspace.shared.notificationCenter.removeObserver(self)
         hideOverlay()
         isRunning = false
@@ -226,28 +237,42 @@ final class OpenMissionControlCore: ObservableObject {
     // MARK: - Key Event Handling
 
     private func handleKeyPress(flags: CGEventFlags, keyCode: CGKeyCode) -> Bool {
-        guard isOverlayShown, let window = hoveredWindow else { return true }
+        guard isOverlayShown else { return true }
+
+        let isReturnKey = keyCode == KeyboardKey.returnKey.rawValue
+            || keyCode == KeyboardKey.keypadEnter.rawValue
+        let hasActionModifier = flags.contains(.maskCommand) || flags.contains(.maskControl)
+            || flags.contains(.maskAlternate) || flags.contains(.maskShift)
+
+        if shortcutActivateWindow, isReturnKey, !hasActionModifier {
+            if let window = hoveredWindow {
+                activateHoveredWindow(window)
+            }
+            return false
+        }
+
+        guard let window = hoveredWindow else { return true }
 
         // Check for Command key
         guard flags.contains(.maskCommand) else { return true }
 
-        switch keyCode {
-        case 12: // Q
+        switch KeyboardKey(rawValue: keyCode) {
+        case .quit: // Q
             if shortcutQuit {
                 performWindowAction(window: window, action: .quit, instigator: .keyboard)
                 return false
             }
-        case 13: // W
+        case .close: // W
             if shortcutClose {
                 performWindowAction(window: window, action: .close, instigator: .keyboard)
                 return false
             }
-        case 46: // M
+        case .minimize: // M
             if shortcutMinimize {
                 performWindowAction(window: window, action: .minimize, instigator: .keyboard)
                 return false
             }
-        case 3: // F
+        case .maximize: // F
             if shortcutMaximize {
                 performWindowAction(window: window, action: .zoom, instigator: .keyboard)
                 return false
@@ -257,6 +282,31 @@ final class OpenMissionControlCore: ObservableObject {
         }
 
         return true
+    }
+
+    private func activateHoveredWindow(_ window: [String: Any]) {
+        guard let location = CGEvent(source: nil)?.location else { return }
+
+        let windowName = window[kCGWindowName as String] as? String ?? ""
+        logger.info("Return shortcut activated window: \(windowName)")
+
+        hideOverlay()
+
+        let source = CGEventSource(stateID: .hidSystemState)
+        let mouseDown = CGEvent(
+            mouseEventSource: source,
+            mouseType: .leftMouseDown,
+            mouseCursorPosition: location,
+            mouseButton: .left
+        )
+        let mouseUp = CGEvent(
+            mouseEventSource: source,
+            mouseType: .leftMouseUp,
+            mouseCursorPosition: location,
+            mouseButton: .left
+        )
+        mouseDown?.post(tap: .cghidEventTap)
+        mouseUp?.post(tap: .cghidEventTap)
     }
 
     // MARK: - Window Fetching
@@ -525,7 +575,7 @@ final class OpenMissionControlCore: ObservableObject {
         }
 
         // Start mouse monitoring when overlay is visible
-        MouseEventMonitor.shared.start()
+        InputEventMonitor.shared.start()
 
         // Do an initial overlay update with current mouse position
         if let mouseLocation = CGEvent(source: nil)?.location {
@@ -537,7 +587,8 @@ final class OpenMissionControlCore: ObservableObject {
         windowFetchTimer?.invalidate()
         windowFetchTimer = nil
         overlayWindow?.orderOut(nil)
-        MouseEventMonitor.shared.stop()
+        hoveredWindow = nil
+        InputEventMonitor.shared.stop()
     }
 
     func recreateOverlay() {

--- a/OpenMissionControl/OpenMissionControlCore.swift
+++ b/OpenMissionControl/OpenMissionControlCore.swift
@@ -73,6 +73,8 @@ final class OpenMissionControlCore: ObservableObject {
     private var windowFetchTimer: Timer?
     @AppStorage(SettingsDefaults.Key.updateDuration) private var updateDuration: Double =
         SettingsDefaults.updateDuration
+    @AppStorage(SettingsDefaults.Key.overlayButtonScale) private var overlayButtonScale: Double =
+        SettingsDefaults.overlayButtonScale
     @AppStorage(SettingsDefaults.Key.shortcutQuit) private var shortcutQuit: Bool =
         SettingsDefaults.shortcutQuit
     @AppStorage(SettingsDefaults.Key.shortcutClose) private var shortcutClose: Bool =
@@ -361,9 +363,12 @@ final class OpenMissionControlCore: ObservableObject {
 
         DispatchQueue.main.async { [self] in
             if let rect = overlayRect {
-                let isHovering = rect.contains(mouseLocation)
+                let isHovering = hoveredWindow != nil && rect.contains(mouseLocation)
                 if isOverlayHovered != isHovering {
                     isOverlayHovered = isHovering
+                }
+                if isHovering {
+                    return
                 }
             }
 
@@ -385,7 +390,8 @@ final class OpenMissionControlCore: ObservableObject {
                     // Convert CG top-left coordinates to NSWindow bottom-left coordinates
                     let screenHeight =
                         NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
-                    let convertedY = screenHeight - y - 40
+                    let sizing = OverlaySizing(scale: overlayButtonScale)
+                    let convertedY = screenHeight - y - sizing.height
 
                     let showQuit =
                         UserDefaults.standard.object(forKey: SettingsDefaults.Key.showQuitButton)
@@ -403,15 +409,17 @@ final class OpenMissionControlCore: ObservableObject {
                             as? Bool ?? SettingsDefaults.showZoomButton
                     let buttonCount = [showQuit, showClose, showMinimize, showZoom].filter { $0 }
                         .count
-                    let overlayWidth = CGFloat(12 + buttonCount * 32)
+                    let overlayWidth = sizing.width(buttonCount: buttonCount)
 
                     let newFrame = NSRect(
-                        x: x + 8, y: convertedY - 8, width: overlayWidth, height: 40
+                        x: x + 8, y: convertedY - 8, width: overlayWidth, height: sizing.height
                     )
                     overlayWindow?.setFrame(newFrame, display: true)
                     overlayWindow?.orderFront(nil)
 
-                    let cgOverlayRect = CGRect(x: x + 8, y: y + 8, width: overlayWidth, height: 40)
+                    let cgOverlayRect = CGRect(
+                        x: x + 8, y: y + 8, width: overlayWidth, height: sizing.height
+                    )
                     overlayRect = cgOverlayRect
                     hoveredWindow = windowInfo
 
@@ -429,7 +437,8 @@ final class OpenMissionControlCore: ObservableObject {
         guard let rect = overlayRect, let window = hoveredWindow else { return }
 
         let localX = location.x - rect.minX
-        var currentX: CGFloat = 8
+        let sizing = OverlaySizing(scale: overlayButtonScale)
+        var currentX = sizing.horizontalPadding
 
         let showQuit =
             UserDefaults.standard.object(forKey: SettingsDefaults.Key.showQuitButton) as? Bool
@@ -445,31 +454,31 @@ final class OpenMissionControlCore: ObservableObject {
                 ?? SettingsDefaults.showZoomButton
 
         if showQuit {
-            if localX >= currentX, localX <= currentX + 24 {
+            if localX >= currentX, localX <= currentX + sizing.buttonSize {
                 performWindowAction(window: window, action: .quit, instigator: .overlay)
             }
-            currentX += 32
+            currentX += sizing.buttonStride
         }
 
         if showClose {
-            if localX >= currentX, localX <= currentX + 24 {
+            if localX >= currentX, localX <= currentX + sizing.buttonSize {
                 performWindowAction(window: window, action: .close, instigator: .overlay)
             }
-            currentX += 32
+            currentX += sizing.buttonStride
         }
 
         if showMinimize {
-            if localX >= currentX, localX <= currentX + 24 {
+            if localX >= currentX, localX <= currentX + sizing.buttonSize {
                 performWindowAction(window: window, action: .minimize, instigator: .overlay)
             }
-            currentX += 32
+            currentX += sizing.buttonStride
         }
 
         if showZoom {
-            if localX >= currentX, localX <= currentX + 24 {
+            if localX >= currentX, localX <= currentX + sizing.buttonSize {
                 performWindowAction(window: window, action: .zoom, instigator: .overlay)
             }
-            currentX += 32
+            currentX += sizing.buttonStride
         }
     }
 

--- a/OpenMissionControl/Utilities/InputEventMonitor.swift
+++ b/OpenMissionControl/Utilities/InputEventMonitor.swift
@@ -1,5 +1,5 @@
 //
-//  MouseEventMonitor.swift
+//  InputEventMonitor.swift
 //  OpenMissionControl
 //
 //  Created by Travis XU on 15/3/2026.
@@ -11,9 +11,9 @@ import Foundation
 import os
 import SwiftUI
 
-/// Monitors global mouse events and notifies registered handlers on click and move events.
-class MouseEventMonitor {
-    static let shared = MouseEventMonitor()
+/// Monitors global input events and notifies registered handlers on click, move, and key events.
+class InputEventMonitor {
+    static let shared = InputEventMonitor()
 
     // MARK: - Types
 
@@ -28,7 +28,7 @@ class MouseEventMonitor {
 
     private let logger = Logger(
         subsystem: "dev.travisxu.OpenMissionControl",
-        category: "MouseEventMonitor"
+        category: "InputEventMonitor"
     )
 
     private var clickHandler: ClickHandler?
@@ -36,7 +36,7 @@ class MouseEventMonitor {
     private var keyHandler: KeyHandler?
     private(set) var isMonitoring: Bool = false
 
-    // MARK: - Click Monitoring (CGEvent tap)
+    // MARK: - Input Monitoring (CGEvent tap)
 
     fileprivate var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
@@ -65,39 +65,39 @@ class MouseEventMonitor {
 
         isMonitoring = true
 
-        startClickMonitoring()
+        startInputMonitoring()
         startMoveMonitoring()
 
-        logger.info("Mouse event monitoring started.")
+        logger.info("Input event monitoring started.")
     }
 
     func stop() {
         guard isMonitoring else { return }
 
-        stopClickMonitoring()
+        stopInputMonitoring()
         stopMoveMonitoring()
 
         isMonitoring = false
-        logger.info("Mouse event monitoring stopped.")
+        logger.info("Input event monitoring stopped.")
     }
 
-    // MARK: - Private: Click Monitoring
+    // MARK: - Private: Input Monitoring
 
-    private func startClickMonitoring() {
+    private func startInputMonitoring() {
         let eventMask = (1 << CGEventType.leftMouseDown.rawValue)
             | (1 << CGEventType.rightMouseDown.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.keyDown.rawValue)
 
         guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
+            tap: .cghidEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: CGEventMask(eventMask),
-            callback: mouseEventMonitorClickCallback,
+            callback: inputEventMonitorCallback,
             userInfo: nil
         ) else {
-            logger.error("Failed to create click event tap. Please grant Accessibility permissions.")
+            logger.error("Failed to create input event tap. Please grant Accessibility permissions.")
             return
         }
 
@@ -109,10 +109,10 @@ class MouseEventMonitor {
         }
 
         CGEvent.tapEnable(tap: tap, enable: true)
-        logger.info("Click event tap started.")
+        logger.info("Input event tap started.")
     }
 
-    private func stopClickMonitoring() {
+    private func stopInputMonitoring() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
@@ -123,7 +123,7 @@ class MouseEventMonitor {
 
         eventTap = nil
         runLoopSource = nil
-        logger.info("Click event tap stopped.")
+        logger.info("Input event tap stopped.")
     }
 
     // MARK: - Private: Move Monitoring
@@ -180,9 +180,9 @@ class MouseEventMonitor {
     }
 }
 
-// MARK: - C Callback for Click Events
+// MARK: - C Callback for Input Events
 
-private func mouseEventMonitorClickCallback(
+private func inputEventMonitorCallback(
     proxy _: CGEventTapProxy,
     type: CGEventType,
     event: CGEvent,
@@ -190,7 +190,7 @@ private func mouseEventMonitorClickCallback(
 ) -> Unmanaged<CGEvent>? {
     // Re-enable tap if it was disabled by timeout or user input
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        if let tap = MouseEventMonitor.shared.eventTap {
+        if let tap = InputEventMonitor.shared.eventTap {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
         return Unmanaged.passRetained(event)
@@ -198,20 +198,20 @@ private func mouseEventMonitorClickCallback(
 
     if type == .leftMouseDown {
         let location = event.location
-        let passDown = MouseEventMonitor.shared.handleClick(at: location, with: .left)
+        let passDown = InputEventMonitor.shared.handleClick(at: location, with: .left)
         if !passDown {
             return nil
         }
     } else if type == .rightMouseDown {
         let location = event.location
-        let passDown = MouseEventMonitor.shared.handleClick(at: location, with: .right)
+        let passDown = InputEventMonitor.shared.handleClick(at: location, with: .right)
         if !passDown {
             return nil
         }
     } else if type == .otherMouseDown {
         let location = event.location
         if let button = CGMouseButton(rawValue: UInt32(event.getIntegerValueField(.mouseEventButtonNumber))) {
-            let passDown = MouseEventMonitor.shared.handleClick(at: location, with: button)
+            let passDown = InputEventMonitor.shared.handleClick(at: location, with: button)
             if !passDown {
                 return nil
             }
@@ -219,7 +219,7 @@ private func mouseEventMonitorClickCallback(
     } else if type == .keyDown {
         let flags = event.flags
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
-        let passDown = MouseEventMonitor.shared.handleKey(flags: flags, keyCode: keyCode)
+        let passDown = InputEventMonitor.shared.handleKey(flags: flags, keyCode: keyCode)
         if !passDown {
             return nil
         }

--- a/OpenMissionControl/Utilities/OverlaySizing.swift
+++ b/OpenMissionControl/Utilities/OverlaySizing.swift
@@ -1,0 +1,33 @@
+//
+//  OverlaySizing.swift
+//  OpenMissionControl
+//
+
+import Foundation
+
+struct OverlaySizing {
+    static let scaleRange: ClosedRange<Double> = 0.5 ... 1.5
+    static let scaleStep: Double = 0.05
+
+    let scale: CGFloat
+
+    init(scale: Double) {
+        self.scale = CGFloat(scale)
+    }
+
+    var buttonSize: CGFloat { 24 * scale }
+    var spacing: CGFloat { 8 * scale }
+    var horizontalPadding: CGFloat { 10 * scale }
+    var verticalPadding: CGFloat { 8 * scale }
+    var borderWidth: CGFloat { 0.5 * scale }
+    var shadowRadius: CGFloat { 3 * scale }
+    var shadowYOffset: CGFloat { scale }
+    var buttonStride: CGFloat { buttonSize + spacing }
+    var height: CGFloat { buttonSize + 2 * verticalPadding }
+
+    func width(buttonCount: Int) -> CGFloat {
+        2 * horizontalPadding
+            + CGFloat(buttonCount) * buttonSize
+            + CGFloat(max(0, buttonCount - 1)) * spacing
+    }
+}

--- a/OpenMissionControl/Utilities/SettingsDefaults.swift
+++ b/OpenMissionControl/Utilities/SettingsDefaults.swift
@@ -25,6 +25,7 @@ enum SettingsDefaults {
         static let shortcutClose = "shortcutClose"
         static let shortcutMinimize = "shortcutMinimize"
         static let shortcutMaximize = "shortcutMaximize"
+        static let shortcutActivateWindow = "shortcutActivateWindow"
 
         static let rightClickAction = "rightClickAction"
         static let middleClickAction = "middleClickAction"
@@ -46,6 +47,7 @@ enum SettingsDefaults {
     static let shortcutClose: Bool = false
     static let shortcutMinimize: Bool = false
     static let shortcutMaximize: Bool = false
+    static let shortcutActivateWindow: Bool = true
 
     static let rightClickAction: WindowAction = .none
     static let middleClickAction: WindowAction = .none

--- a/OpenMissionControl/Utilities/SettingsDefaults.swift
+++ b/OpenMissionControl/Utilities/SettingsDefaults.swift
@@ -17,6 +17,7 @@ enum SettingsDefaults {
         static let showZoomButton = "showZoomButton"
 
         static let overlayTheme = "overlayTheme"
+        static let overlayButtonScale = "overlayButtonScale"
 
         static let updateDuration = "updateDuration"
         static let mouseUpdateDuration = "mouseUpdateDuration"
@@ -39,6 +40,7 @@ enum SettingsDefaults {
     static let showZoomButton: Bool = true
 
     static let overlayTheme: OverlayTheme = .default
+    static let overlayButtonScale: Double = 1.0
 
     static let updateDuration: Double = 0.25
     static let mouseUpdateDuration: Double = 0.1

--- a/OpenMissionControl/Views/ColoredMinimalOverlayView.swift
+++ b/OpenMissionControl/Views/ColoredMinimalOverlayView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ColoredMinimalOverlayView: View {
+    let sizing: OverlaySizing
+
     @ObservedObject private var openMissionControlCore = OpenMissionControlCore.shared
 
     @AppStorage(SettingsDefaults.Key.showQuitButton) private var showQuitButton: Bool =
@@ -20,7 +22,7 @@ struct ColoredMinimalOverlayView: View {
         SettingsDefaults.showZoomButton
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: sizing.spacing) {
             if showQuitButton {
                 overlayIcon(color: .purple, icon: "power", iconSize: 10)
             }
@@ -37,22 +39,22 @@ struct ColoredMinimalOverlayView: View {
                 overlayIcon(color: .green, icon: "arrow.up.backward.and.arrow.down.forward", iconSize: 12)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, sizing.horizontalPadding)
+        .padding(.vertical, sizing.verticalPadding)
         .background(
             Capsule()
                 .fill(Color(NSColor.windowBackgroundColor).opacity(0.95))
         )
         .overlay(
             Capsule()
-                .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
+                .stroke(Color.primary.opacity(0.15), lineWidth: sizing.borderWidth)
         )
     }
 
     private func overlayIcon(color: Color, icon: String, iconSize: CGFloat) -> some View {
         Image(systemName: icon)
-            .font(.system(size: iconSize, weight: .bold))
+            .font(.system(size: iconSize * sizing.scale, weight: .bold))
             .foregroundColor(color)
-            .frame(width: 24, height: 24)
+            .frame(width: sizing.buttonSize, height: sizing.buttonSize)
     }
 }

--- a/OpenMissionControl/Views/DefaultOverlayView.swift
+++ b/OpenMissionControl/Views/DefaultOverlayView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct DefaultOverlayView: View {
+    let sizing: OverlaySizing
+
     @Environment(\.isPreview) private var isPreview
     @ObservedObject private var openMissionControlCore = OpenMissionControlCore.shared
 
@@ -21,7 +23,7 @@ struct DefaultOverlayView: View {
         SettingsDefaults.showZoomButton
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: sizing.spacing) {
             if showQuitButton {
                 trafficLight(color: .purple, icon: "power", iconSize: 10)
             }
@@ -38,15 +40,15 @@ struct DefaultOverlayView: View {
                 trafficLight(color: .green, icon: "arrow.up.backward.and.arrow.down.forward", iconSize: 10)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, sizing.horizontalPadding)
+        .padding(.vertical, sizing.verticalPadding)
         .background(
             Capsule()
                 .fill(Color(NSColor.windowBackgroundColor).opacity(0.95))
         )
         .overlay(
             Capsule()
-                .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
+                .stroke(Color.primary.opacity(0.15), lineWidth: sizing.borderWidth)
         )
     }
 
@@ -58,10 +60,13 @@ struct DefaultOverlayView: View {
                     startPoint: .top,
                     endPoint: .bottom
                 ))
-                .frame(width: 24, height: 24)
-                .shadow(color: color.opacity(0.4), radius: 3, x: 0, y: 1)
+                .frame(width: sizing.buttonSize, height: sizing.buttonSize)
+                .shadow(
+                    color: color.opacity(0.4), radius: sizing.shadowRadius,
+                    x: 0, y: sizing.shadowYOffset
+                )
             Image(systemName: icon)
-                .font(.system(size: iconSize, weight: .bold))
+                .font(.system(size: iconSize * sizing.scale, weight: .bold))
                 .foregroundColor((openMissionControlCore.isOverlayHovered || isPreview) ? Color.black.opacity(0.45) : .clear)
         }
     }

--- a/OpenMissionControl/Views/MinimalOverlayView.swift
+++ b/OpenMissionControl/Views/MinimalOverlayView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MinimalOverlayView: View {
+    let sizing: OverlaySizing
+
     @ObservedObject private var openMissionControlCore = OpenMissionControlCore.shared
 
     @AppStorage(SettingsDefaults.Key.showQuitButton) private var showQuitButton: Bool =
@@ -20,7 +22,7 @@ struct MinimalOverlayView: View {
         SettingsDefaults.showZoomButton
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: sizing.spacing) {
             if showQuitButton {
                 overlayIcon(icon: "power", iconSize: 10)
             }
@@ -37,22 +39,22 @@ struct MinimalOverlayView: View {
                 overlayIcon(icon: "arrow.up.backward.and.arrow.down.forward", iconSize: 12)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, sizing.horizontalPadding)
+        .padding(.vertical, sizing.verticalPadding)
         .background(
             Capsule()
                 .fill(Color(NSColor.windowBackgroundColor).opacity(0.95))
         )
         .overlay(
             Capsule()
-                .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
+                .stroke(Color.primary.opacity(0.15), lineWidth: sizing.borderWidth)
         )
     }
 
     private func overlayIcon(icon: String, iconSize: CGFloat) -> some View {
         Image(systemName: icon)
-            .font(.system(size: iconSize, weight: .bold))
+            .font(.system(size: iconSize * sizing.scale, weight: .bold))
             .foregroundColor(.primary)
-            .frame(width: 24, height: 24)
+            .frame(width: sizing.buttonSize, height: sizing.buttonSize)
     }
 }

--- a/OpenMissionControl/Views/OverlayView.swift
+++ b/OpenMissionControl/Views/OverlayView.swift
@@ -27,17 +27,21 @@ enum OverlayTheme: String, CaseIterable, DisplayNameable {
 struct OverlayView: View {
     @AppStorage(SettingsDefaults.Key.overlayTheme) private var currentTheme: OverlayTheme =
         SettingsDefaults.overlayTheme
+    @AppStorage(SettingsDefaults.Key.overlayButtonScale) private var overlayButtonScale: Double =
+        SettingsDefaults.overlayButtonScale
     var isPreview: Bool = false
 
     var body: some View {
+        let sizing = OverlaySizing(scale: overlayButtonScale)
+
         Group {
             switch currentTheme {
             case .default:
-                DefaultOverlayView()
+                DefaultOverlayView(sizing: sizing)
             case .minimal:
-                MinimalOverlayView()
+                MinimalOverlayView(sizing: sizing)
             case .coloredMinimal:
-                ColoredMinimalOverlayView()
+                ColoredMinimalOverlayView(sizing: sizing)
             }
         }
         .environment(\.isPreview, isPreview)

--- a/OpenMissionControl/Views/SettingsView.swift
+++ b/OpenMissionControl/Views/SettingsView.swift
@@ -227,6 +227,8 @@ struct SettingsView: View {
         SettingsDefaults.showZoomButton
     @AppStorage(SettingsDefaults.Key.overlayTheme) private var currentTheme: OverlayTheme =
         SettingsDefaults.overlayTheme
+    @AppStorage(SettingsDefaults.Key.overlayButtonScale) private var overlayButtonScale: Double =
+        SettingsDefaults.overlayButtonScale
     @AppStorage(SettingsDefaults.Key.updateDuration) private var updateDuration: Double =
         SettingsDefaults.updateDuration
     @AppStorage(SettingsDefaults.Key.mouseUpdateDuration) private var mouseUpdateDuration: Double =
@@ -344,6 +346,30 @@ struct SettingsView: View {
 
                         SettingsDivider()
 
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("Overlay Size")
+                                    .font(.system(size: 13, weight: .medium))
+                                Spacer()
+                                Text(String(format: "%.0f%%", overlayButtonScale * 100))
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Slider(
+                                value: $overlayButtonScale,
+                                in: OverlaySizing.scaleRange,
+                                step: OverlaySizing.scaleStep
+                            )
+                            .controlSize(.small)
+                            Text("The size of the Mission Control overlay.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+
+                        SettingsDivider()
+
                         SettingToggleRow(
                             icon: "power",
                             iconColor: solidColor(color: .purple),
@@ -382,7 +408,7 @@ struct SettingsView: View {
 
                 // MARK: Preview
 
-                if showCloseButton || showMinimizeButton || showZoomButton {
+                if showQuitButton || showCloseButton || showMinimizeButton || showZoomButton {
                     VStack(alignment: .leading, spacing: 6) {
                         sectionHeader("Preview")
 

--- a/OpenMissionControl/Views/SettingsView.swift
+++ b/OpenMissionControl/Views/SettingsView.swift
@@ -239,6 +239,8 @@ struct SettingsView: View {
         SettingsDefaults.shortcutMinimize
     @AppStorage(SettingsDefaults.Key.shortcutMaximize) private var shortcutMaximize: Bool =
         SettingsDefaults.shortcutMaximize
+    @AppStorage(SettingsDefaults.Key.shortcutActivateWindow) private var shortcutActivateWindow:
+        Bool = SettingsDefaults.shortcutActivateWindow
     @AppStorage(SettingsDefaults.Key.rightClickAction) private var rightClickAction: WindowAction =
         SettingsDefaults.rightClickAction
     @AppStorage(SettingsDefaults.Key.middleClickAction) private var middleClickAction:
@@ -407,6 +409,13 @@ struct SettingsView: View {
                     sectionHeader("Keyboard Shortcuts")
 
                     SettingsCard {
+                        SettingToggleRow(
+                            title: "Activate Window (Return/Enter)",
+                            isOn: $shortcutActivateWindow
+                        )
+
+                        SettingsDivider()
+
                         SettingToggleRow(
                             title: "Quit (⌘Q)",
                             isOn: $shortcutQuit


### PR DESCRIPTION
Hello, and thank you for creating such a useful app! Since I would like this app, an alternative to Mission Control Plus, to add even more features than it does, I made the following changes.
Please understand that I may have missed something, and let me know if you find any mistakes or errors.

Thank you, and have a great day!

## Summary

Added a setting to adjust the size of the Mission Control overlay controls, as well as the ability to activate the currently hovered window using the Return key.

## Changes

- Added an `Overlay Size` slider to the overlay settings section.
- The size can be adjusted from 50% to 150%; at 100%, the existing default size is maintained.
- The entire traffic-light-style control group, including button sizes, spacing, padding, and container structure, scales consistently.
- The same sizing calculations are used for both the actual Mission Control overlay and the preview in the settings screen.
- When Mission Control is open, hovering over a window thumbnail and pressing the Return/Enter key activates that window and exits Mission Control.
- Existing button visibility, hover behavior, and click behavior remain unchanged.

## Technical Details

- Added `overlayButtonScale` to `SettingsDefaults` and persist its value using `@AppStorage`.
- Added a shared `OverlaySizing` abstraction that calculates button sizes, spacing, padding, corner radii, and the overall overlay size from a single scale value.
- Applied the same sizing calculations to `OpenMissionControlCore`, which handles the native overlay window and hit testing.
- Passed the configured size to each overlay view variant so that the Default, Minimal, and Colored Minimal styles all maintain the same proportions.
- Reused `OverlayView` in the settings screen preview so that the actual overlay and preview use the same sizing calculation path.
- Adjusted the overlay position and mouse hit-test areas to match the scaled structure so that changing the size does not alter button or hover behavior.
- Generalized the existing mouse event monitor into `InputEventMonitor` so that mouse and keyboard events can share a single event-tap lifecycle and handler structure.
- Reused the existing hovered-window state and window activation path to handle Return/Enter without adding separate target state.
- When no window is being hovered, nothing happens; existing mouse monitoring and keyboard shortcut behavior are preserved.