### PR TITLE
Restore overlay functionality after window dragging

### DIFF
--- a/OpenMissionControl/OpenMissionControlCore.swift
+++ b/OpenMissionControl/OpenMissionControlCore.swift
@@ -38,6 +38,13 @@ enum WindowAction: Int, CaseIterable, DisplayNameable {
     }
 }
 
+enum WindowDragState: Int, CaseIterable {
+    case none = 0
+    case leftClickDownOnWindow = 1
+    case leftClickDraggingWindow = 2
+    case leftClickUpAfterDraggedWindow = 3
+}
+
 enum Instigator: Int, CaseIterable, DisplayNameable {
     case overlay
     case keyboard
@@ -120,6 +127,16 @@ final class OpenMissionControlCore: ObservableObject {
             self.logger.debug(
                 "Mouse clicked at: \(location.x), \(location.y) (button: \(button.rawValue))")
             return self.handleMouseClick(at: location, with: button)
+        }
+        InputEventMonitor.shared.setDragHandler { [weak self] location, button in
+            guard let self = self else { return }
+
+            self.handleMouseDrag(at: location, with: button)
+        }
+        InputEventMonitor.shared.setMouseUpHandler { [weak self] location, button in
+            guard let self = self else { return true }
+
+            return self.handleMouseUp(at: location, with: button)
         }
         InputEventMonitor.shared.setMoveHandler { [weak self] location in
             guard let self = self else { return }
@@ -209,7 +226,8 @@ final class OpenMissionControlCore: ObservableObject {
             case .left:
                 logger.debug(
                     "Captured left click on hovered window at (\(location.x), \(location.y)).")
-                hideOverlay()
+                windowDragState = .leftClickDownOnWindow
+                hideOverlay(keepInputMonitoring: true)
                 return true
             case .right:
                 logger.debug(
@@ -229,11 +247,37 @@ final class OpenMissionControlCore: ObservableObject {
             }
         }
 
+        hideOverlay()
         return true
     }
 
     private func handleMouseMove(to location: CGPoint) {
+        guard windowDragState == .none else { return }
+
         updateOverlay(at: location)
+    }
+
+    private func handleMouseDrag(at _: CGPoint, with button: CGMouseButton) {
+        guard button == .left, windowDragState == .leftClickDownOnWindow else { return }
+
+        logger.debug("Mouse started dragging the clicked window.")
+        windowDragState = .leftClickDraggingWindow
+    }
+
+    @discardableResult
+    private func handleMouseUp(at _: CGPoint, with button: CGMouseButton) -> Bool {
+        guard button == .left, windowDragState != .none else { return true }
+
+        let shouldRestoreOverlay = windowDragState == .leftClickDraggingWindow
+        if shouldRestoreOverlay, isOverlayShown {
+            logger.debug("Mouse released the dragged window, restoring overlay.")
+            windowDragState = .leftClickUpAfterDraggedWindow
+            recreateOverlay()
+        } else {
+            windowDragState = .none
+        }
+
+        return true
     }
 
     // MARK: - Key Event Handling
@@ -354,6 +398,7 @@ final class OpenMissionControlCore: ObservableObject {
     private var overlayWindow: NSWindow?
     private(set) var overlayRect: CGRect?
     private(set) var hoveredWindow: [String: Any]?
+    private var windowDragState: WindowDragState = .none
 
     @Published private(set) var isOverlayShown: Bool = false
     @Published private(set) var isOverlayHovered: Bool = false
@@ -591,17 +636,32 @@ final class OpenMissionControlCore: ObservableObject {
         // Start mouse monitoring when overlay is visible
         InputEventMonitor.shared.start()
 
-        // Do an initial overlay update with current mouse position
-        if let mouseLocation = CGEvent(source: nil)?.location {
-            updateOverlay(at: mouseLocation)
+        // Do an initial overlay update with current mouse position.
+        // (Skip the update after a window drag to ensure that the overlay doesn't
+        // get shown immediately at the coordinates where the drag ended, because
+        // this would result in rendering the overlay at invalid position.)
+        if windowDragState == .none {
+            if let mouseLocation = CGEvent(source: nil)?.location {
+                updateOverlay(at: mouseLocation)
+            }
+        }
+        else {
+            windowDragState = .none
         }
     }
 
-    func hideOverlay() {
+    func hideOverlay(keepInputMonitoring: Bool = false) {
         windowFetchTimer?.invalidate()
         windowFetchTimer = nil
         overlayWindow?.orderOut(nil)
         hoveredWindow = nil
+        isOverlayHovered = false
+
+        if keepInputMonitoring {
+            return
+        }
+
+        windowDragState = .none
         InputEventMonitor.shared.stop()
     }
 

--- a/OpenMissionControl/Utilities/InputEventMonitor.swift
+++ b/OpenMissionControl/Utilities/InputEventMonitor.swift
@@ -18,6 +18,8 @@ class InputEventMonitor {
     // MARK: - Types
 
     typealias ClickHandler = (_ location: CGPoint, _ buttonCode: CGMouseButton) -> Bool
+    typealias DragHandler = (_ location: CGPoint, _ buttonCode: CGMouseButton) -> Void
+    typealias MouseUpHandler = (_ location: CGPoint, _ buttonCode: CGMouseButton) -> Bool
     typealias MoveHandler = (_ location: CGPoint) -> Void
     typealias KeyHandler = (_ flags: CGEventFlags, _ keyCode: CGKeyCode) -> Bool
 
@@ -32,6 +34,8 @@ class InputEventMonitor {
     )
 
     private var clickHandler: ClickHandler?
+    private var dragHandler: DragHandler?
+    private var mouseUpHandler: MouseUpHandler?
     private var moveHandler: MoveHandler?
     private var keyHandler: KeyHandler?
     private(set) var isMonitoring: Bool = false
@@ -50,6 +54,14 @@ class InputEventMonitor {
 
     func setClickHandler(_ handler: @escaping ClickHandler) {
         clickHandler = handler
+    }
+
+    func setDragHandler(_ handler: @escaping DragHandler) {
+        dragHandler = handler
+    }
+
+    func setMouseUpHandler(_ handler: @escaping MouseUpHandler) {
+        mouseUpHandler = handler
     }
 
     func setMoveHandler(_ handler: @escaping MoveHandler) {
@@ -86,6 +98,8 @@ class InputEventMonitor {
     private func startInputMonitoring() {
         let eventMask =
             (1 << CGEventType.leftMouseDown.rawValue)
+            | (1 << CGEventType.leftMouseDragged.rawValue)
+            | (1 << CGEventType.leftMouseUp.rawValue)
             | (1 << CGEventType.rightMouseDown.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.keyDown.rawValue)
@@ -168,6 +182,15 @@ class InputEventMonitor {
         return clickHandler?(location, button) ?? true
     }
 
+    fileprivate func handleDrag(at location: CGPoint, with button: CGMouseButton) {
+        dragHandler?(location, button)
+    }
+
+    @discardableResult
+    fileprivate func handleMouseUp(at location: CGPoint, with button: CGMouseButton) -> Bool {
+        return mouseUpHandler?(location, button) ?? true
+    }
+
     private func handleMove(to location: CGPoint) {
         moveHandler?(location)
     }
@@ -203,6 +226,14 @@ private func inputEventMonitorCallback(
     if type == .leftMouseDown {
         let location = event.location
         let passDown = InputEventMonitor.shared.handleClick(at: location, with: .left)
+        if !passDown {
+            return nil
+        }
+    } else if type == .leftMouseDragged {
+        InputEventMonitor.shared.handleDrag(at: event.location, with: .left)
+    } else if type == .leftMouseUp {
+        let location = event.location
+        let passDown = InputEventMonitor.shared.handleMouseUp(at: location, with: .left)
         if !passDown {
             return nil
         }


### PR DESCRIPTION
Hello again! I found a minor inconsistency with how the app determines whether to stop displaying the overlays based on mouse input events. Not sure if this is an oversight or purposeful omission, but I'd like to propose a fix.

## Reproduction steps

"Current result" is observed on version 9. "Expected result" can be observed with this PR fix applied.

### Case 1

1. Open Mission Control.
2. Start dragging a window (eg. because we want to move it to a different desktop or display).
3. Stop dragging the window (cancel drag or drop it on a different desktop).
4. Hover over the same or a different window.

Current result: no overlays will be displayed again until MC is relaunched or virtual desktop is switched.
Expected result: overlay should be displayed above the hovered window.

### Case 2

1. Open Mission Control.
2. Click and hold left mouse button while not hovering over any window.
3. Start hovering over windows.

Current result: overlay gets displayed above windows.
Expected result: overlay should not be displayed above windows, because they aren't highlighted and MC will close as soon as left mouse button is released.

## Solution

Additional logic is added to restore overlay handling when left mouse click/drag won't result in Mission Control getting closed.

## Implementation

1. `InputEventMonitor` now also listens for left mouse up and left mouse drag events.
2. Mouse down (`handleMouseClick`) **always** shuts down overlay rendering (previously this happened only when a window was clicked).
3. A small state machine (enum `WindowDragState`) is added to track mouse left click lifecycle (down->drag->up). Tracking only takes place if the click was started when hovering over a window.
4. If the state machine detected a drag between mouse down and mouse up, the user must have dragged a window - this means that MC won't close, so on mouse up we should restore overlay rendering.